### PR TITLE
Update hooks for azd 0.8.0

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,6 +8,18 @@ services:
     project: ./app/backend
     language: py
     host: appservice
+    hooks:
+      prepackage:
+        windows:
+          shell: pwsh
+          run:  cd ../frontend;npm install;npm run build
+          interactive: true
+          continueOnError: false
+        posix:
+          shell: sh
+          run:  cd ../frontend;npm install;npm run build
+          interactive: true
+          continueOnError: false
 hooks:
     postprovision:
       windows:
@@ -18,16 +30,5 @@ hooks:
       posix:
         shell: sh
         run: ./scripts/prepdocs.sh
-        interactive: true
-        continueOnError: false
-    predeploy:
-      windows:
-        shell: pwsh
-        run:  cd ./app/frontend;npm install;npm run build
-        interactive: true
-        continueOnError: false
-      posix:
-        shell: sh
-        run:  cd ./app/frontend;npm install;npm run build
         interactive: true
         continueOnError: false


### PR DESCRIPTION
azd version 0.8.0 packs the application before creating azure resources (when running azd up) Then `azd deploy` use the output from that packing to publish the app to Azure. The `predeploy` hook is not valid anymore on this scenario to include the frontend to the backend. Instead, we need to switch to use `prepackage` for the backend service, so the frontend is attached before creating the package.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->